### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/hosts/dorothy/desktop.nix
+++ b/hosts/dorothy/desktop.nix
@@ -39,7 +39,7 @@
   '';
 
   nixpkgs.overlays = [
-    # https://nixos.wiki/wiki/GNOME#Dynamic_triple_buffering
+    # https://wiki.nixos.org/wiki/GNOME#Dynamic_triple_buffering
     # https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1441
     # GNOME 46: triple-buffering-v4-46
     (_final: prev: {

--- a/hosts/karenina/network.nix
+++ b/hosts/karenina/network.nix
@@ -6,7 +6,7 @@ let
   inherit (config.sops) secrets;
 in
 {
-  # https://nixos.wiki/wiki/Systemd-networkd
+  # https://wiki.nixos.org/wiki/Systemd-networkd
 
   networking = {
     hostName = "karenina";


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️